### PR TITLE
Escape quotes in eval(), unit tests, and others

### DIFF
--- a/msl-client-browser/README.md
+++ b/msl-client-browser/README.md
@@ -1,0 +1,16 @@
+msl-client-browser
+==================
+
+Testing
+-------
+
+To execute unit tests, run
+
+> npm test
+
+or alternatively, if you have karma installed, you can run
+
+> npm install
+> karma start
+
+To download all dependencies and run the tests.

--- a/msl-client-browser/appcontainer-driver.js
+++ b/msl-client-browser/appcontainer-driver.js
@@ -181,7 +181,7 @@ Element.prototype.toggle = function() {
 }
 
 /**
- * Escapes single and double quotes of the given string.
+ * Escapes single, double quotes, and backslashes of the given string.
  * @name escapeString
  * @param {string} str - string to escape
  * @returns {string} the escaped string
@@ -200,8 +200,17 @@ function escapeString(str) {
         throw new Error('\'str\' must be a string');
     }
 
-    // regex replace all occurrance ' and " to escaped \' and \"
-    var escaped_str = str.replace(/'/g, '\\\'').replace(/"/g, '\\"');
+    /*
+     * Need to escape backslashes (\) first because escaping ' and " will also 
+     * add a \, which interferes with \ escaping.
+     */
+    var escaped_str = str;
+    // regex replace all \ to \\
+    escaped_str = escaped_str.replace(/\\/g, '\\\\');
+    // regex replace all ' to \'
+    escaped_str = escaped_str.replace(/'/g, '\\\'');
+    // regex replace all " to \"
+    escaped_str = escaped_str.replace(/"/g, '\\"');
 
     return escaped_str;
 

--- a/msl-client-browser/appcontainer-driver.js
+++ b/msl-client-browser/appcontainer-driver.js
@@ -92,90 +92,117 @@ Element.prototype.getJQueryElement = function() {
 /**************************************/
 Element.prototype.val = function(str) {
   if(str != undefined) {
-    window.frames['mslappcontainer'].eval('$("' + this.locator + '").val("' + str + '")');
+    window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").val("' + escapeString(str) + '")');
   }else {
-    return window.frames['mslappcontainer'].eval('$("' + this.locator + '").val()');
+    return window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").val()');
   }
 }
 
 Element.prototype.text = function() {
-  return window.frames['mslappcontainer'].eval('$("' + this.locator + '").text()');
+  return window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").text()');
 }
 
 Element.prototype.attr = function(attributeName, value) {
   if(value != undefined) {
-    window.frames['mslappcontainer'].eval('$("' + this.locator + '").attr("' + attributeName + '", "' + value  + '")');    
+    window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").attr("' + escapeString(attributeName) + '", "' + escapeString(value)  + '")');    
   }else {
-    return window.frames['mslappcontainer'].eval('$("' + this.locator + '").attr("' + attributeName + '")'); 
+    return window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").attr("' + escapeString(attributeName) + '")'); 
   }
 }
 
 Element.prototype.size = function() {
-  return window.frames['mslappcontainer'].eval('$("' + this.locator + '").size()');
+  return window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").size()');
 }
 
 /*********************/
 /** Keyboard Events **/
 /*********************/
 Element.prototype.keydown = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").keydown()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").keydown()');
 }
 
 Element.prototype.keypress = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").keypress()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").keypress()');
 }
 
 Element.prototype.keyup = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").keyup()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").keyup()');
 }
 
 /******************/
 /** Mouse Events **/
 /******************/
 Element.prototype.click = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").click()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").click()');
 }
 
 Element.prototype.dblclick = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").dblclick()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").dblclick()');
 }
 
 Element.prototype.focusout = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").focusout()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").focusout()');
 }
 
 Element.prototype.hover = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").hover()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").hover()');
 }
 
 Element.prototype.mousedown = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").mousedown()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").mousedown()');
 }
 
 Element.prototype.mouseenter = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").mouseenter()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").mouseenter()');
 }
 
 Element.prototype.mouseleave = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").mouseleave()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").mouseleave()');
 }
 
 Element.prototype.mousemove = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").mousemove()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").mousemove()');
 }
 
 Element.prototype.mouseout = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").mouseout()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").mouseout()');
 }
 
 Element.prototype.mouseover = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").mouseover()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").mouseover()');
 }
 
 Element.prototype.mouseup = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").mouseup()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").mouseup()');
 }
 
 Element.prototype.toggle = function() {
-  window.frames['mslappcontainer'].eval('$("' + this.locator + '").toggle()');
+  window.frames['mslappcontainer'].eval('$("' + escapeString(this.locator) + '").toggle()');
+}
+
+/**
+ * Escapes single and double quotes of the given string.
+ * @name escapeString
+ * @param {string} str - string to escape
+ * @returns {string} the escaped string
+ */
+function escapeString(str) {
+
+    if(str === undefined) {
+        throw new Error('\'str\' is required');
+    }
+
+    if(str === null) {
+        throw new Error('\'str\' must not be null');
+    }
+
+    if(typeof str !== 'string') {
+        throw new Error('\'str\' must be a string');
+    }
+
+    // regex replace all occurrance ' and " to escaped \' and \"
+    var escaped_str = str.replace(/'/g, '\\\'').replace(/"/g, '\\"');
+
+    return escaped_str;
+
 }

--- a/msl-client-browser/karma.conf.js
+++ b/msl-client-browser/karma.conf.js
@@ -1,0 +1,12 @@
+module.exports = function(config) {
+    config.set({
+        frameworks: ['jasmine'],
+        files: [
+            'appcontainer-driver.js',
+            'test/**/*-spec.js'
+        ],
+        reporters: ['mocha'],
+        browsers: ['PhantomJS'],
+        singleRun: true
+    });
+};

--- a/msl-client-browser/package.json
+++ b/msl-client-browser/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "jasmine-core": "^2.1.3",
     "karma": "^0.12.31",
+    "karma-cli": "0.0.4",
     "karma-jasmine": "^0.3.4",
     "karma-mocha-reporter": "^0.3.1",
     "karma-phantomjs-launcher": "^0.1.4"

--- a/msl-client-browser/package.json
+++ b/msl-client-browser/package.json
@@ -20,7 +20,7 @@
       "name": "Jake Sheppard"
     }
   ],
-  "repositories": [{
+  "repository": [{
     "type": "git",
     "url": "git://github.com/FINRAOS/MSL.git"
   }],
@@ -30,5 +30,16 @@
       "type": "Apache 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
-  ]
+  ],
+  "devDependencies": {
+    "jasmine-core": "^2.1.3",
+    "karma": "^0.12.31",
+    "karma-jasmine": "^0.3.4",
+    "karma-mocha-reporter": "^0.3.1",
+    "karma-phantomjs-launcher": "^0.1.4"
+  },
+  "scripts": {
+    "pretest": "npm install",
+    "test": "karma start"
+  }
 }

--- a/msl-client-browser/test/appcontainer-driver-spec.js
+++ b/msl-client-browser/test/appcontainer-driver-spec.js
@@ -12,7 +12,17 @@ describe('appcontainer-driver', function() {
             expect(escaped).toEqual('MSL stands for \\"Mock Service Layer\\"');
         });
 
-        it('does nothing if the string does not contain quotes', function() {
+        it('escapes backslashes', function() {
+            var escaped = escapeString('MSL now uses \\ to escape quotes');
+            expect(escaped).toEqual('MSL now uses \\\\ to escape quotes');
+        });
+
+        it('escapes backslashes and quotes', function() {
+            var escaped = escapeString('MSL now uses \\ to escape quotes, "this quote should be escaped"');
+            expect(escaped).toEqual('MSL now uses \\\\ to escape quotes, \\"this quote should be escaped\\"');
+        });
+
+        it('does nothing if the string does not contain quotes or backslashes', function() {
             var escaped = escapeString('MSL is cool!');
             expect(escaped).toEqual('MSL is cool!');
         });

--- a/msl-client-browser/test/appcontainer-driver-spec.js
+++ b/msl-client-browser/test/appcontainer-driver-spec.js
@@ -1,0 +1,76 @@
+describe('appcontainer-driver', function() {
+    
+    describe('escapeString()', function() {
+
+        it('escapes single quotes', function() {
+            var escaped = escapeString("I'm using MSL");
+            expect(escaped).toEqual("I\\'m using MSL");
+        });
+
+        it('escapes double quotes', function() {
+            var escaped = escapeString('MSL stands for "Mock Service Layer"');
+            expect(escaped).toEqual('MSL stands for \\"Mock Service Layer\\"');
+        });
+
+        it('does nothing if the string does not contain quotes', function() {
+            var escaped = escapeString('MSL is cool!');
+            expect(escaped).toEqual('MSL is cool!');
+        });
+
+        it('throws if given no arguments', function() {
+            expect(function() {
+                escapeString();
+            }).toThrow();
+        });
+
+        it('throws if given null argument', function() {
+            expect(function() {
+                escapeString(null);
+            }).toThrow();
+        });
+
+        it('throws if given defined, non-null, non-string argument', function() {
+            expect(function() {
+                escapeString(0);
+            }).toThrow();
+
+            expect(function() {
+                escapeString(1);
+            }).toThrow();
+
+            expect(function() {
+                escapeString(-1);
+            }).toThrow();
+
+            expect(function() {
+                escapeString(2);
+            }).toThrow();
+
+            expect(function() {
+                escapeString(true);
+            }).toThrow();
+
+            expect(function() {
+                escapeString(false);
+            }).toThrow();
+
+            expect(function() {
+                escapeString([]);
+            }).toThrow();
+
+            expect(function() {
+                escapeString([123]);
+            }).toThrow();
+
+            expect(function() {
+                escapeString({});
+            }).toThrow();
+
+            expect(function() {
+                escapeString({a:123});
+            }).toThrow();
+        });
+
+    });
+    
+});


### PR DESCRIPTION
Added new function escapeString() in /msl-client-browser/appcontainer-driver.js and modified all calls to eval() to escape the string before concatenating into expression.

Added new karma test under /msl-client-browser/ to unit test this new functionality, along with a readme to explain how to run the unit test.

Also changed /msl-client-browser/package.json where the property "repositories" should have been "repository." This was causing warning messages when npm install was run.